### PR TITLE
アドレスがまだ一つも存在しない行(ラベル: )に初めて追加すると改行が追加されてしまうのを防ぐ

### DIFF
--- a/lib/sugoi_aliases_updator/line_parser.rb
+++ b/lib/sugoi_aliases_updator/line_parser.rb
@@ -5,7 +5,7 @@ module SugoiAliasesUpdator
     def initialize(line)
       @is_aliaes_line = /^(.*):(\s*)([\w@\., -]*)/ === line
       @label = $1
-      @margin = $2
+      @margin = $2 && $2.delete(?\n)
       @emails_line = $3
     end
   end


### PR DESCRIPTION
```
label-foo: 
```

$ sugoi_aliases_updator foo@example.com TO=label-foo
==>

```
label-foo:
foo@example.com
```

fix: ==>

```
label-foo: foo@example.com
```
